### PR TITLE
tweak(fxmanifest): add es_extended to dependencies

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -3,6 +3,7 @@ fx_version 'adamant'
 game 'gta5'
 
 dependencies {
+	"es_extended",
 	"PolyZone"
 }
 


### PR DESCRIPTION
Prevent non exist export getSharedObject error with importing es_extended/imports.lua if qTarget is loaded before es_extended