### PR TITLE
Support multiple job

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -36,10 +36,12 @@ if not Config.Standalone then
 	end
 
 	M.CheckOptions = function(data, entity, distance)
-		if (data.distance == nil or distance <= data.distance)
-		and (data.job == nil or (data.job == ESX.PlayerData.job.name or data.job[ESX.PlayerData.job.name] and data.job[ESX.PlayerData.job.name] <= ESX.PlayerData.job.grade))
-		and (data.required_item == nil or data.required_item and M.ItemCount(data.required_item) > 0)
-		and (data.canInteract == nil or data.canInteract(entity)) then return true
+		for k,v in pairs(data.job) do
+			if (data.distance == nil or distance <= data.distance)
+			and (v == nil or (v == ESX.PlayerData.job.name or v[ESX.PlayerData.job.name] and v[ESX.PlayerData.job.name] <= ESX.PlayerData.job.grade))
+			and (data.required_item == nil or data.required_item and M.ItemCount(data.required_item) > 0)
+			and (data.canInteract == nil or data.canInteract(entity)) then return true
+			end
 		end
 		return false
 	end


### PR DESCRIPTION
**Example**
exports['qtarget']:AddBoxZone("MissionRowDutyClipboard", vector3(441.7989, -982.0529, 30.67834), 0.45, 0.35, {
	name="MissionRowDutyClipboard",
	heading=11.0,
	debugPoly=false,
	minZ=30.77834,
	maxZ=30.87834,
	}, {
		options = {
			{
				event = "qrp_duty:goOnDuty",
				icon = "fas fa-sign-in-alt",
				label = "Sign In",
				job = {"police", "ambulance", {["mechanic"] = 2}},
			},
			{
				event = "qrp_duty:goOffDuty",
				icon = "fas fa-sign-out-alt",
				label = "Sign Out",
				job = {"police"},
			},
		},
		distance = 3.5
})