### PR TITLE
fix: Update job on job change

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -26,6 +26,10 @@ if ESX then
 	RegisterNetEvent('esx:playerLoaded', function(xPlayer)
 		ESX.PlayerData = xPlayer
 	end)
+	
+	RegisterNetEvent('esx:setJob', function(job)
+		ESX.PlayerData.job = job
+	end)
 
 	local ItemCount = function(item)
 		if Config.OxInventory then


### PR DESCRIPTION
Solves an issue where qtarget wasn't updating the job properly not allowing access to certain zones